### PR TITLE
fix: Add 'socials executive' role to team members

### DIFF
--- a/src/server/api/routers/team/service.ts
+++ b/src/server/api/routers/team/service.ts
@@ -35,6 +35,7 @@ const categorizeTeamMembersByRole = (
     "marketing executive",
     "technical executive",
     "industry & sponsorships executive",
+    "socials executive",
   ];
 
   teamMembers.forEach((member) => {


### PR DESCRIPTION
## Description

Fixed ordering of socials exec on the teams page

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [ ] I had tested the change locally (running `npm run preview`)
- [ ] Reviewed changes in both mobile and desktop by device
- [ ] My code changes follow the Code Style Guideline
- [ ] My PR title follows conventional change log standards
- [ ] I have included a screenshot (if it is an UI change)
