### PR TITLE
fix: update the styling of flagship events to fix image-text overlap

### DIFF
--- a/src/app/_components/flagship-events.tsx
+++ b/src/app/_components/flagship-events.tsx
@@ -41,7 +41,7 @@ function FlagshipCard({
     target: cardRef,
     offset: ["start end", "end start"],
   });
-  const imageY = useTransform(scrollYProgress, [0, 1], ["0%", "12%"]);
+  const imageY = useTransform(scrollYProgress, [0, 1], ["-6%", "6%"]);
 
   return (
     <motion.div
@@ -50,24 +50,26 @@ function FlagshipCard({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-100px" }}
       transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
-      className={`grid items-stretch gap-0 lg:grid-cols-12 ${reversed ? "direction-rtl" : ""}`}
+      className={`grid items-stretch gap-0 xl:grid-cols-12 ${reversed ? "direction-rtl" : ""}`}
       style={{ direction: "ltr" }}
     >
       {/* Image panel */}
       <div
         className={`group relative overflow-hidden ${
-          reversed
-            ? "lg:order-2 lg:col-span-7 lg:col-start-6"
-            : "lg:col-span-7"
+          reversed ? "xl:order-2 xl:col-span-7 xl:col-start-6" : "xl:col-span-7"
         }`}
       >
-        <Link href={event.url} target="_blank" className="relative block aspect-4/3 overflow-hidden lg:aspect-auto lg:h-full lg:min-h-[500px]">
+        <Link
+          href={event.url}
+          target="_blank"
+          className="relative block aspect-4/3 overflow-hidden xl:aspect-auto xl:h-full xl:min-h-[500px]"
+        >
           <motion.div className="absolute inset-0" style={{ y: imageY }}>
             <Image
               src={event.imageSrc}
               alt={event.name}
               fill
-              className="scale-110 object-cover transition-transform duration-700 group-hover:scale-[1.15]"
+              className="scale-[1.15] object-cover transition-transform duration-700 group-hover:scale-[1.2]"
               sizes="(max-width: 1024px) 100vw, 58vw"
               priority
               quality={85}
@@ -75,20 +77,20 @@ function FlagshipCard({
           </motion.div>
           {/* Gradient overlays */}
           <div className="absolute inset-0 bg-linear-to-t from-[#030a18] via-transparent to-transparent opacity-80" />
-          <div className={`absolute inset-0 bg-linear-to-r ${reversed ? "from-transparent to-[#030a18]/70" : "from-[#030a18]/70 to-transparent"}`} />
+          <div
+            className={`absolute inset-0 bg-linear-to-r ${reversed ? "from-transparent to-[#030a18]/70" : "from-[#030a18]/70 to-transparent"}`}
+          />
 
           {/* Hover CTA */}
-          <div className="absolute inset-0 flex items-center justify-center bg-primary-500/0 transition-colors duration-500 group-hover:bg-primary-500/10">
-            <motion.div
-              className="flex items-center gap-3 border border-white/0 px-6 py-3 text-sm font-bold tracking-[0.2em] text-white uppercase opacity-0 backdrop-blur-none transition-all duration-500 group-hover:border-white/30 group-hover:opacity-100 group-hover:backdrop-blur-sm"
-            >
+          <div className="bg-primary-500/0 group-hover:bg-primary-500/10 absolute inset-0 flex items-center justify-center transition-colors duration-500">
+            <motion.div className="flex items-center gap-3 border border-white/0 px-6 py-3 text-sm font-bold tracking-[0.2em] text-white uppercase opacity-0 backdrop-blur-none transition-all duration-500 group-hover:border-white/30 group-hover:opacity-100 group-hover:backdrop-blur-sm">
               Explore
               <HiArrowRight className="size-4" />
             </motion.div>
           </div>
 
           {/* Index number on image */}
-          <span className="absolute bottom-6 right-6 text-8xl font-black leading-none text-white/5 lg:text-[10rem]">
+          <span className="absolute right-6 bottom-6 text-8xl leading-none font-black text-white/5 lg:text-[10rem]">
             {event.index}
           </span>
         </Link>
@@ -96,28 +98,28 @@ function FlagshipCard({
 
       {/* Content panel */}
       <div
-        className={`relative flex flex-col justify-center px-6 py-12 md:px-12 lg:py-20 ${
+        className={`relative flex flex-col justify-center overflow-hidden px-6 py-12 md:px-12 xl:py-20 ${
           reversed
-            ? "lg:order-1 lg:col-span-5 lg:pr-16 lg:pl-0"
-            : "lg:col-span-5 lg:pr-0 lg:pl-16"
+            ? "xl:order-1 xl:col-span-5 xl:pr-16 xl:pl-0"
+            : "xl:col-span-5 xl:pr-0 xl:pl-16"
         }`}
       >
         {/* Vertical accent line */}
         <div
-          className={`absolute top-0 hidden h-full w-px bg-white/8 lg:block ${
+          className={`absolute top-0 hidden h-full w-px bg-white/8 xl:block ${
             reversed ? "right-0" : "left-0"
           }`}
         />
 
-        <span className="mb-6 text-[0.6rem] font-bold tracking-[0.4em] text-primary-400/60 uppercase">
+        <span className="text-primary-400/60 mb-6 text-[0.6rem] font-bold tracking-[0.4em] uppercase">
           Flagship Event {event.index}
         </span>
 
-        <h3 className="mb-2 text-6xl font-black leading-[0.85] tracking-tighter text-white md:text-7xl lg:text-8xl">
+        <h3 className="mb-2 text-6xl leading-[0.85] font-black tracking-tighter text-white md:text-7xl lg:text-8xl">
           {event.name.toUpperCase()}
         </h3>
 
-        <p className="mb-8 text-xs font-bold tracking-[0.3em] text-primary-400 uppercase">
+        <p className="text-primary-400 mb-8 text-xs font-bold tracking-[0.3em] uppercase">
           {event.tagline}
         </p>
 
@@ -128,9 +130,9 @@ function FlagshipCard({
         <Link
           href={event.url}
           target="_blank"
-          className="group/link inline-flex items-center gap-3 text-sm font-bold tracking-[0.2em] text-white uppercase transition-colors hover:text-primary-400"
+          className="group/link hover:text-primary-400 inline-flex items-center gap-3 text-sm font-bold tracking-[0.2em] text-white uppercase transition-colors"
         >
-          <span className="flex size-12 items-center justify-center bg-primary-500 transition-colors group-hover/link:bg-primary-400">
+          <span className="bg-primary-500 group-hover/link:bg-primary-400 flex size-12 items-center justify-center transition-colors">
             <HiArrowRight className="size-5 transition-transform group-hover/link:translate-x-0.5" />
           </span>
           Learn More
@@ -149,17 +151,17 @@ export default function FlagshipEvents() {
   const marqueeX = useTransform(scrollYProgress, [0, 1], ["0%", "-15%"]);
 
   return (
-    <section ref={sectionRef} className="relative overflow-hidden bg-[#030a18] text-white">
+    <section
+      ref={sectionRef}
+      className="relative overflow-hidden bg-[#030a18] text-white"
+    >
       {/* Top divider — scrolling text marquee */}
-      <div className="relative overflow-hidden border-y border-primary-500/20 bg-primary-500 py-4">
-        <motion.div
-          className="flex whitespace-nowrap"
-          style={{ x: marqueeX }}
-        >
+      <div className="border-primary-500/20 bg-primary-500 relative overflow-hidden border-y py-4">
+        <motion.div className="flex whitespace-nowrap" style={{ x: marqueeX }}>
           {Array.from({ length: 8 }).map((_, i) => (
             <span
               key={i}
-              className="mx-8 text-3xl font-black italic tracking-tight text-white/90 md:text-4xl"
+              className="mx-8 text-3xl font-black tracking-tight text-white/90 italic md:text-4xl"
             >
               FLAGSHIP EVENTS
             </span>
@@ -176,7 +178,7 @@ export default function FlagshipEvents() {
           transition={{ duration: 0.7 }}
           className="mb-20"
         >
-          <span className="mb-4 block text-xs font-bold tracking-[0.3em] text-primary-400 uppercase">
+          <span className="text-primary-400 mb-4 block text-xs font-bold tracking-[0.3em] uppercase">
             // The Main Events
           </span>
           <h2 className="text-5xl font-bold md:text-6xl lg:text-8xl">
@@ -199,7 +201,7 @@ export default function FlagshipEvents() {
       </div>
 
       {/* Bottom divider — scrolling text marquee (reverse) */}
-      <div className="relative overflow-hidden border-y border-primary-500/20 bg-primary-500 py-4">
+      <div className="border-primary-500/20 bg-primary-500 relative overflow-hidden border-y py-4">
         <motion.div
           className="flex whitespace-nowrap"
           style={{ x: useTransform(scrollYProgress, [0, 1], ["0%", "15%"]) }}
@@ -207,7 +209,7 @@ export default function FlagshipEvents() {
           {Array.from({ length: 8 }).map((_, i) => (
             <span
               key={i}
-              className="mx-8 text-3xl font-black italic tracking-tight text-white/90 md:text-4xl"
+              className="mx-8 text-3xl font-black tracking-tight text-white/90 italic md:text-4xl"
             >
               FLAGSHIP EVENTS
             </span>


### PR DESCRIPTION
## Description

This changes implemented change the tailwind styling by switching the grid-cols for mobile view lg (at 1024px) to xl (at 1280px) so that the text size remains the same but the flag ship images move above the text without any overlap.

## Type of change

<!-- Please delete options that are not relevant -->

- [x] Bugfix (non-breaking change which fixes an issue)

reference(notion|figma|issue): [https://www.notion.so/](https://www.notion.so/Fix-Clipping-on-Home-Page-33b8f3d5ed488035aba3fd13bd25318a?source=copy_link)

## 📷 Screenshots (if any)

Desktop:
New screenshot with fixes:
<img width="1087" height="798" alt="image" src="https://github.com/user-attachments/assets/6fa4e251-9d99-4496-8982-ed9877a1719a" />

Screenshot with old/buggy code:
<img width="1092" height="786" alt="image" src="https://github.com/user-attachments/assets/1b874be9-61e5-4d15-9faf-c73f23570205" />


## Checklist

- [x] I had tested the change locally (running `npm run preview`)
- [ ] Reviewed changes in both mobile and desktop by device
- [x] My code changes follow the Code Style Guideline
- [x] My PR title follows conventional change log standards
- [x] I have included a screenshot (if it is an UI change)
