### PR TITLE
feat: point Buildathon flagship link to buildathon.ramsocunsw.org

### DIFF
--- a/src/lib/constants/urls.ts
+++ b/src/lib/constants/urls.ts
@@ -14,8 +14,7 @@ export const LINKTREE_URL = "https://linktr.ee/RAMSocUNSW";
 export const JOIN_US_URL =
   "https://member.arc.unsw.edu.au/s/clubdetail?clubid=0016F0000371VybQAE";
 export const SUMOBOTS_URL = "https://sumobots.ramsocunsw.org";
-export const BUILDATHON_URL =
-  "https://www.facebook.com/events/1154974769420620";
+export const BUILDATHON_URL = "https://buildathon.ramsocunsw.org";
 
 // Helper Functions
 export const getFacebookEventUrl = (eventId: string | number) =>


### PR DESCRIPTION
Replace the Facebook event URL with the dedicated Buildathon subdomain,
matching the pattern already used for Sumobots.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U58NuFVKNkbFC1FscR8obY